### PR TITLE
Make ignoring directories configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rake-notes (0.2.0)
+    rake-notes (0.2.1)
       colored
       rake
 
@@ -26,3 +26,6 @@ PLATFORMS
 DEPENDENCIES
   rake-notes!
   rspec
+
+BUNDLED WITH
+   1.16.0

--- a/lib/rake/notes/version.rb
+++ b/lib/rake/notes/version.rb
@@ -1,5 +1,5 @@
 module Rake
   module Notes
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
@astashov PTAL

This is to fix rake-notes to ignore subdirectories. Some bug was causing it to fail while parsing gem files under ./vender/bundle on travis-ci. Now we can just ignore stuff that's not part of the main repo.

The gem itself is very simple but pretty old and unmaintained. I forked it I could customize it. I'll submit a PR to the main repo but I'm not counting on a response.